### PR TITLE
Add privacy policy page and update footer links

### DIFF
--- a/about.html
+++ b/about.html
@@ -36,7 +36,9 @@
   </main>
   
   <footer>
-    <p>&copy; 2025 The Storyteller’s House. All rights reserved.</p>
+    <p>&copy; 2025 The Storyteller’s House. All rights reserved. |
+      <a href="privacy.html">Privacy Policy</a>
+    </p>
   </footer>
 </body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -49,9 +49,11 @@
   </main>
   
   <footer>
-    <p>&copy; 2025 The Storyteller’s House. All rights reserved.</p>
+    <p>&copy; 2025 The Storyteller’s House. All rights reserved. |
+      <a href="privacy.html">Privacy Policy</a>
+    </p>
   </footer>
-  
+
   <script>
     // Simple form handler
     document.querySelector('.contact-form').addEventListener('submit', function(e) {

--- a/index.html
+++ b/index.html
@@ -37,7 +37,9 @@
 
   <!-- Footer -->
   <footer>
-    <p>&copy; 2025 The Storyteller’s House. All rights reserved.</p>
+    <p>&copy; 2025 The Storyteller’s House. All rights reserved. |
+      <a href="privacy.html">Privacy Policy</a>
+    </p>
   </footer>
 
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Privacy Policy - The Storyteller’s House</title>
+  <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Open+Sans:wght@400;600&display=swap"
+        rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="fade-in">
+  <header>
+    <nav class="navbar">
+      <div class="logo">
+        <a href="index.html">The Storyteller’s House</a>
+      </div>
+      <ul class="nav-links">
+        <li><a href="index.html">Home</a></li>
+        <li><a href="about.html">About</a></li>
+        <li><a href="stories.html">Stories</a></li>
+        <li><a href="contact.html">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
+
+  <main class="container">
+    <section class="privacy">
+      <h1>Privacy Policy</h1>
+      <p><strong>Last updated:</strong> January 1, 2025</p>
+      <p>
+        The Storyteller’s House respects your privacy and is committed to being transparent
+        about the information we do—and do not—collect. This policy outlines how we handle
+        personal data when you interact with our website.
+      </p>
+
+      <h2>Information We Collect</h2>
+      <p>
+        We do not collect or store personal data when you browse this website. The only
+        personal information we receive is what you choose to share with us directly
+        through email or other messages.
+      </p>
+
+      <h2>Email Communications</h2>
+      <p>
+        If you send us an email, we will use the information you provide solely to respond
+        to your message. We retain your email address and the contents of the conversation
+        only for as long as the communication remains active. Once the conversation ends,
+        we delete the correspondence and any personal details it contains.
+      </p>
+
+      <h2>Cookies and Tracking</h2>
+      <p>
+        We do not use cookies, analytics scripts, or any other tracking technologies on
+        this website.
+      </p>
+
+      <h2>Third-Party Services</h2>
+      <p>
+        We do not share personal information with third parties, and we do not use external
+        analytics or advertising services. Our web hosting provider may collect standard
+        technical logs (such as IP addresses) required for security and maintenance, but
+        we do not access or store that information.
+      </p>
+
+      <h2>Data Security</h2>
+      <p>
+        We take reasonable steps to protect any personal information you share with us from
+        unauthorized access, disclosure, alteration, or destruction.
+      </p>
+
+      <h2>Children’s Privacy</h2>
+      <p>
+        The Storyteller’s House is designed for audiences of all ages. We encourage parents
+        and guardians to supervise children’s use of the internet and to contact us if they
+        believe a child has provided personal information without consent so we can remove it.
+      </p>
+
+      <h2>Changes to This Policy</h2>
+      <p>
+        We may update this privacy policy from time to time to reflect changes to our
+        practices or for other operational, legal, or regulatory reasons. When we make
+        changes, we will update the “Last updated” date at the top of this page.
+      </p>
+
+      <h2>Contact Us</h2>
+      <p>
+        If you have any questions about this policy or how we handle your information,
+        please reach out through the form on our <a href="contact.html">Contact</a> page.
+      </p>
+    </section>
+  </main>
+
+  <footer>
+    <p>&copy; 2025 The Storyteller’s House. All rights reserved. |
+      <a href="privacy.html">Privacy Policy</a>
+    </p>
+  </footer>
+</body>
+</html>

--- a/stories.html
+++ b/stories.html
@@ -56,7 +56,9 @@
   </main>
 
   <footer>
-    <p>&copy; 2025 The Storyteller’s House. All rights reserved.</p>
+    <p>&copy; 2025 The Storyteller’s House. All rights reserved. |
+      <a href="privacy.html">Privacy Policy</a>
+    </p>
   </footer>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -114,3 +114,33 @@ footer {
   font-size: 0.9rem;
   margin-top: 3rem;
 }
+
+footer a {
+  color: var(--secondary-color);
+  text-decoration: underline;
+}
+
+footer a:hover {
+  color: var(--highlight-color);
+}
+
+.privacy h1 {
+  font-size: 2.2rem;
+  margin-bottom: 1rem;
+}
+
+.privacy h2 {
+  font-size: 1.4rem;
+  margin-top: 2rem;
+  color: var(--primary-color);
+}
+
+.privacy p,
+.privacy ul {
+  margin-bottom: 1rem;
+}
+
+.privacy ul {
+  padding-left: 1.5rem;
+  list-style: disc;
+}


### PR DESCRIPTION
## Summary
- add a dedicated privacy policy page outlining data collection, retention, and cookie practices
- link the privacy policy from every page footer and style the footer link for readability

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68e4ebed7b4083238563e3315e512fb7